### PR TITLE
Possible to set DO from external Client through ROS service

### DIFF
--- a/abb_librws/include/abb_librws/rws_common.h
+++ b/abb_librws/include/abb_librws/rws_common.h
@@ -366,9 +366,54 @@ struct SystemConstants
     static const std::string ABB_SCALABLE_IO_0_DI16;
 
     /**
+     * \brief Name of defined IO signal for digital output 1
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO1;
+  
+    /**
+     * \brief Name of defined IO signal for digital output 2
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO2;
+
+    /**
+     * \brief Name of defined IO signal for digital output 3
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO3;
+
+    /**
+     * \brief Name of defined IO signal for digital output 4
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO4;
+
+    /**
+     * \brief Name of defined IO signal for digital output 5
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO5;
+
+    /**
+     * \brief Name of defined IO signal for digital output 6
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO6;
+
+    /**
+     * \brief Name of defined IO signal for digital output 7
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO7;
+
+    /**
+     * \brief Name of defined IO signal for digital output 8
+     */
+    static const std::string ABB_SCALABLE_IO_0_DO8;
+
+    /**
      * \brief Vector containing all the possible digital inputs of omnicore controller
      */
     static const std::vector<std::string> OmnicoreDigitalInputs;
+
+    /**
+     * \brief Vector containing all the possible digital outputs of omnicore controller
+     */
+    static const std::vector<std::string> OmnicoreDigitalOutputs;
   };
     
   /**

--- a/abb_librws/src/rws_common.cpp
+++ b/abb_librws/src/rws_common.cpp
@@ -215,6 +215,15 @@ const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI14  = "ABB_Sca
 const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI15  = "ABB_Scalable_IO_0_DI15";
 const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI16  = "ABB_Scalable_IO_0_DI16";
 
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO1   = "ABB_Scalable_IO_0_DO1";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO2   = "ABB_Scalable_IO_0_DO2";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO3   = "ABB_Scalable_IO_0_DO3";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO4   = "ABB_Scalable_IO_0_DO4";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO5   = "ABB_Scalable_IO_0_DO5";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO6   = "ABB_Scalable_IO_0_DO6";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO7   = "ABB_Scalable_IO_0_DO7";
+const std::string SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO8   = "ABB_Scalable_IO_0_DO8";
+
 const std::vector<std::string> SystemConstants::IOSignals::OmnicoreDigitalInputs = 
                                                   { 
                                                     SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI1, 
@@ -233,6 +242,18 @@ const std::vector<std::string> SystemConstants::IOSignals::OmnicoreDigitalInputs
                                                     // SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI14,
                                                     // SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI15,
                                                     // SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DI16
+                                                  };
+
+const std::vector<std::string> SystemConstants::IOSignals::OmnicoreDigitalOutputs = 
+                                                  {
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO1,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO2,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO3,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO4,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO5,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO6,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO7,
+                                                    SystemConstants::IOSignals::ABB_SCALABLE_IO_0_DO8,
                                                   };
 
 const std::string SystemConstants::RAPID::RAPID_FALSE = "FALSE";

--- a/omnicore_interface/CMakeLists.txt
+++ b/omnicore_interface/CMakeLists.txt
@@ -39,6 +39,7 @@ add_service_files(
   FILES
   moveJ_rapid.srv
   moveL_rapid.srv
+  set_digital_output.srv
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/omnicore_interface/srv/set_digital_output.srv
+++ b/omnicore_interface/srv/set_digital_output.srv
@@ -1,4 +1,10 @@
-uint8 index     # digital output port(1 ~ 8)
+# This service is used to set Digital Outputs valut (from 1 to 8) to values which are HIGH or LOW
+# To be noticed that the service works only if from RobotStudio has been set that the Digital Outputs
+# can be set from an external client 
+uint8 LOW  = 0
+uint8 HIGH = 1
+
+uint8 port     # digital output port(1 ~ 8)
 uint8 value     # 0 : OFF, 1 : ON
 ---
 bool success

--- a/omnicore_interface/srv/set_digital_output.srv
+++ b/omnicore_interface/srv/set_digital_output.srv
@@ -1,0 +1,4 @@
+uint8 index     # digital output port(1 ~ 8)
+uint8 value     # 0 : OFF, 1 : ON
+---
+bool success

--- a/ros_control_omnicore/include/rws.hpp
+++ b/ros_control_omnicore/include/rws.hpp
@@ -17,6 +17,7 @@
 // Custom ROS services
 #include <omnicore_interface/moveJ_rapid.h>
 #include <omnicore_interface/moveL_rapid.h>
+#include <omnicore_interface/set_digital_output.h>
 #include <controller_manager_msgs/UnloadController.h>
 #include <controller_manager_msgs/LoadController.h>
 #include <controller_manager_msgs/SwitchController.h>
@@ -65,10 +66,12 @@ private:
 	bool MoveJRapidSrv(omnicore_interface::moveJ_rapidRequest& req, omnicore_interface::moveJ_rapidResponse& res);
 	bool MoveLRapidSrv(omnicore_interface::moveL_rapidRequest& req, omnicore_interface::moveL_rapidResponse& res);
 	bool ShutdownSrv(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
+	bool SetDigitalOutputSrv(omnicore_interface::set_digital_outputRequest& req, omnicore_interface::set_digital_outputResponse& res);
 
 	// Generic funtions
 	void 		   LoadToolData();
 	std_msgs::Byte ReadDigitalInputs();
+	bool		   SetDigitalOutput(uint8_t index, uint8_t value);
 	void 		   PublishOmnicoreState();
 
 	std::string robot_name;
@@ -94,6 +97,7 @@ private:
 	ros::ServiceServer server_moveL_rapid;
 	ros::ServiceServer server_set_egm_params;
 	ros::ServiceServer server_egm_shutdown;
+	ros::ServiceServer server_set_digital_output;
 
 	// Ros services clients
 	ros::ServiceClient client_load_controller;


### PR DESCRIPTION
The title is self explanatory. A service has been added to set the digital outputs (from 1-8):
`/set_digital_output`

To be noticed that the service works only if from RobotStudio has been set that the Digital Outputs can be set from an external client 

Cheers